### PR TITLE
TAR directory size fix in FileInfo

### DIFF
--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -57,9 +57,9 @@ class FileInfo
         $file = new FileInfo();
         
         if(is_dir($path))
-			$size = 0;
-		else
-			$size = filesize($path);
+		$size = 0;
+	else
+		$size = filesize($path);
         
         $file->setPath($path);
         $file->setIsdir(is_dir($path));

--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -55,13 +55,18 @@ class FileInfo
 
         $stat = stat($path);
         $file = new FileInfo();
-
+        
+        if(is_dir($path))
+			$size = 0;
+		else
+			$size = filesize($path);
+        
         $file->setPath($path);
         $file->setIsdir(is_dir($path));
         $file->setMode(fileperms($path));
         $file->setOwner(fileowner($path));
         $file->setGroup(filegroup($path));
-        $file->setSize(filesize($path));
+        $file->setSize($size);
         $file->setUid($stat['uid']);
         $file->setGid($stat['gid']);
         $file->setMtime($stat['mtime']);


### PR DESCRIPTION
As reported here https://github.com/splitbrain/php-archive/issues/15#issuecomment-283276163 , i am providing the fix for the directory size FIleInfo class

From my testing, this seems to work well with 7zip now