### PR TITLE
fixing addFile while original file size changes during archiving

### DIFF
--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -57,9 +57,9 @@ class FileInfo
         $file = new FileInfo();
         
         if(is_dir($path))
-			$size = 0;
-		else
-			$size = filesize($path);
+		$size = 0;
+	else
+		$size = filesize($path);
         
         $file->setPath($path);
         $file->setIsdir(is_dir($path));

--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -55,18 +55,13 @@ class FileInfo
 
         $stat = stat($path);
         $file = new FileInfo();
-        
-        if(is_dir($path))
-		$size = 0;
-	else
-		$size = filesize($path);
-        
+
         $file->setPath($path);
         $file->setIsdir(is_dir($path));
         $file->setMode(fileperms($path));
         $file->setOwner(fileowner($path));
         $file->setGroup(filegroup($path));
-        $file->setSize($size);
+        $file->setSize(filesize($path));
         $file->setUid($stat['uid']);
         $file->setGid($stat['gid']);
         $file->setMtime($stat['mtime']);
@@ -79,10 +74,11 @@ class FileInfo
     }
 
     /**
-     * @return int
+     * @return int the filesize. always 0 for directories
      */
     public function getSize()
     {
+        if($this->isdir) return 0;
         return $this->size;
     }
 

--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -55,13 +55,18 @@ class FileInfo
 
         $stat = stat($path);
         $file = new FileInfo();
-
+        
+        if(is_dir($path))
+			$size = 0;
+		else
+			$size = filesize($path);
+        
         $file->setPath($path);
         $file->setIsdir(is_dir($path));
         $file->setMode(fileperms($path));
         $file->setOwner(fileowner($path));
         $file->setGroup(filegroup($path));
-        $file->setSize(filesize($path));
+        $file->setSize($size);
         $file->setUid($stat['uid']);
         $file->setGid($stat['gid']);
         $file->setMtime($stat['mtime']);

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -248,10 +248,11 @@ class Tar extends Archive
         if (!$fp) {
             throw new ArchiveIOException('Could not open file for reading: '.$file);
         }
-
-        // create file header
-        $this->writeFileHeader($fileinfo);
 		
+        // create file header
+        $archive_header_position = ftell($this->fh);
+        $this->writeFileHeader($fileinfo);
+			
         // write data
         while (!feof($fp)) {
             $data = fread($fp, 512);
@@ -264,6 +265,22 @@ class Tar extends Archive
             $packed = pack("a512", $data);
             $this->writebytes($packed);
         }
+        
+        $file_offset = ftell($fp);
+        
+        //rewrite header with new size if file size changed while reading
+        if($file_offset && $file_offset != $fileinfo->getSize())
+        {
+			$archive_current_position = ftell($this->fh);
+			fseek($this->fh, $archive_header_position);
+			
+			$fileinfo->setSize(ftell($fp));
+			$this->writeFileHeader($fileinfo);
+
+			fseek($this->fh, $archive_current_position);
+
+		}
+
         fclose($fp);
     }
 

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -250,7 +250,11 @@ class Tar extends Archive
         }
 		
         // create file header
-        $archive_header_position = ftell($this->fh);
+        if(is_resource($this->fh))
+        {
+			$archive_header_position = ftell($this->fh);
+		}
+		
         $this->writeFileHeader($fileinfo);
 			
         // write data
@@ -269,7 +273,7 @@ class Tar extends Archive
         $file_offset = ftell($fp);
         
         //rewrite header with new size if file size changed while reading
-        if($file_offset && $file_offset != $fileinfo->getSize())
+        if(is_resource($this->fh) && $file_offset && $file_offset != $fileinfo->getSize())
         {
 		$archive_current_position = ftell($this->fh);
 		fseek($this->fh, $archive_header_position);

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -251,7 +251,7 @@ class Tar extends Archive
 
         // create file header
         $this->writeFileHeader($fileinfo);
-
+		
         // write data
         while (!feof($fp)) {
             $data = fread($fp, 512);

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -271,15 +271,14 @@ class Tar extends Archive
         //rewrite header with new size if file size changed while reading
         if($file_offset && $file_offset != $fileinfo->getSize())
         {
-			$archive_current_position = ftell($this->fh);
-			fseek($this->fh, $archive_header_position);
+		$archive_current_position = ftell($this->fh);
+		fseek($this->fh, $archive_header_position);
 			
-			$fileinfo->setSize(ftell($fp));
-			$this->writeFileHeader($fileinfo);
+		$fileinfo->setSize(ftell($fp));
+		$this->writeFileHeader($fileinfo);
 
-			fseek($this->fh, $archive_current_position);
-
-		}
+		fseek($this->fh, $archive_current_position);
+	}
 
         fclose($fp);
     }

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -249,7 +249,7 @@ class Tar extends Archive
             throw new ArchiveIOException('Could not open file for reading: '.$file);
         }
 		
-        // create file header
+        //create file header
         if(is_resource($this->fh))
         {
 			$archive_header_position = ftell($this->fh);


### PR DESCRIPTION
When adding a file which size is being changed during archiving, the archive would become corrupt because the size in the header is different than the size of the actual data written. So an additional check should be done and if the sizes are different, the header should be updated. A quick test would be to create an infinite loop where you write 1 byte to a test.txt file and then trying to add that file to the archive and extracting the archive. 

The error one would get on extraction is "Header does not match it's checksum" because the next file added would not be fetched correctly, and it's header is not seeked at the correct point.
