### PR TITLE
Issue #29

### DIFF
--- a/src/Tar.php
+++ b/src/Tar.php
@@ -256,33 +256,36 @@ class Tar extends Archive
             throw new ArchiveIOException('Archive has been closed, files can no longer be added');
         }
 
-        $fp = @fopen($file, 'rb');
-        if (!$fp) {
-            throw new ArchiveIOException('Could not open file for reading: '.$file);
-        }
-
         // create file header
         $this->writeFileHeader($fileinfo);
 
-        // write data
-        $read = 0;
-        while (!feof($fp)) {
-            $data = fread($fp, 512);
-            $read += strlen($data);
-            if ($data === false) {
-                break;
+        // write data, but only if we have data to write.
+        // note: on Windows fopen() on a directory will fail, so we prevent
+        // errors on Windows by testing if we have data to write.
+        if (!$fileinfo->getIsdir() && $fileinfo->getSize() > 0) {
+            $read = 0;
+            $fp = @fopen($file, 'rb');
+            if (!$fp) {
+                throw new ArchiveIOException('Could not open file for reading: ' . $file);
             }
-            if ($data === '') {
-                break;
+            while (!feof($fp)) {
+                $data = fread($fp, 512);
+                $read += strlen($data);
+                if ($data === false) {
+                    break;
+                }
+                if ($data === '') {
+                    break;
+                }
+                $packed = pack("a512", $data);
+                $this->writebytes($packed);
             }
-            $packed = pack("a512", $data);
-            $this->writebytes($packed);
-        }
-        fclose($fp);
+            fclose($fp);
 
-        if($read != $fileinfo->getSize()) {
-            $this->close();
-            throw new ArchiveCorruptedException("The size of $file changed while reading, archive corrupted. read $read expected ".$fileinfo->getSize());
+            if ($read != $fileinfo->getSize()) {
+                $this->close();
+                throw new ArchiveCorruptedException("The size of $file changed while reading, archive corrupted. read $read expected ".$fileinfo->getSize());
+            }
         }
 
         if(is_callable($this->callback)) {

--- a/tests/TarTestCase.php
+++ b/tests/TarTestCase.php
@@ -662,12 +662,12 @@ class TarTestCase extends TestCase
 
     public function testAddFileWithInvalidFile()
     {
-        $this->expectException(ArchiveIOException::class);
+        $this->expectException(FileInfoException::class);
         $archive = sys_get_temp_dir() . '/dwtartest' . md5(time()) . '.tar';
 
         $tar = new Tar();
         $tar->create($archive);
-        $tar->addFile('archive_file', false);
+        $tar->addFile('archive_file', 'a-non-existing-file.txt');
     }
 
     public function testAddDataWithArchiveStreamIsClosed()


### PR DESCRIPTION
fopen() on a folder on Windows might fail. Prevent calling it when adding a file by checking if it is a directory or if its size = 0.

Note: adding a unit test is difficult as it won't be unit tested on Windows. This change should pass all existing unit tests and that should suffice as prove that it does not introduce a new error.