### PR TITLE
Avoid a file exists error instead of supressing it

### DIFF
--- a/src/Tar.php
+++ b/src/Tar.php
@@ -166,7 +166,9 @@ class Tar extends Archive
             // create output directory
             $output    = $outdir.'/'.$fileinfo->getPath();
             $directory = ($fileinfo->getIsdir()) ? $output : dirname($output);
-            @mkdir($directory, 0777, true);
+            if (!file_exists($directory)) {
+                mkdir($directory, 0777, true);
+            }
 
             // extract data
             if (!$fileinfo->getIsdir()) {


### PR DESCRIPTION
Suppressing the mkdir error causes a lot of noise in symfony dev logs if there are multiple files in a subdirectory of the tar file.  Only try to create the subdirectory if it does not exist.