### PR TITLE
A bunch of enhancements for dealing with large tar archives

### DIFF
--- a/tests/TarTestCase.php
+++ b/tests/TarTestCase.php
@@ -778,6 +778,32 @@ class TarTestCase extends TestCase
         $this->assertTrue(true); // succeed if no exception, yet
     }
 
+    public function testNumberEncodeDecode()
+    {
+        // 2^34 + 17 = 2^2 * 2^32 + 17
+        $refValue = (1 << 34) + 17;
+        $encoded = Tar::numberEncode($refValue, 12);
+        $this->assertEquals(pack('CCnNN', 128, 0, 0, 1 << 2, 17), $encoded);
+        $decoded = Tar::numberDecode($encoded);
+        $this->assertEquals($refValue, $decoded);
+
+        $encoded = Tar::numberEncode($refValue, 7);
+        $this->assertEquals(pack('CnN', 128, 1 << 2, 17), $encoded);
+        $decoded = Tar::numberDecode($encoded);
+        $this->assertEquals($refValue, $decoded);
+
+        $refValue = -1234;
+        $encoded = Tar::numberEncode($refValue, 12);
+        $this->assertEquals(pack('CCnNN', 0xFF, 0xFF, 0xFFFF, 0xFFFFFFFF, -1234), $encoded);
+        $decoded = Tar::numberDecode($encoded);
+        $this->assertEquals($refValue, $decoded);
+
+        $encoded = Tar::numberEncode($refValue, 3);
+        $this->assertEquals(pack('Cn', 0xFF, -1234), $encoded);
+        $decoded = Tar::numberDecode($encoded);
+        $this->assertEquals($refValue, $decoded);
+    }
+
     /**
      * recursive rmdir()/unlink()
      *

--- a/tests/TarTestCase.php
+++ b/tests/TarTestCase.php
@@ -804,6 +804,31 @@ class TarTestCase extends TestCase
         $this->assertEquals($refValue, $decoded);
     }
 
+    public function testReadCurrentEntry()
+    {
+        $tar = new Tar();
+        $tar->open(__DIR__ . '/tar/test.tar');
+        $out = sys_get_temp_dir() . '/dwtartest' . md5(time());
+        $tar->extract($out);
+
+        $tar = new Tar();
+        $tar->open(__DIR__ . '/tar/test.tar');
+        $pathsRead = array();
+        foreach($tar->yieldContents() as $i) {
+            $this->assertFileExists($out . '/' . $i->getPath());
+            if ($i->getIsdir()) {
+                $this->assertEquals('', $tar->readCurrentEntry());
+            } else {
+                $this->assertStringEqualsFile($out . '/' . $i->getPath(), $tar->readCurrentEntry());
+            }
+            $pathsRead[] = $i->getPath();
+        }
+        $pathsReadRef = array('tar', 'tar/testdata1.txt', 'tar/foobar', 'tar/foobar/testdata2.txt');
+        $this->assertEquals($pathsReadRef, $pathsRead);
+
+        self::RDelete($out);
+    }
+
     /**
      * recursive rmdir()/unlink()
      *


### PR DESCRIPTION
This pull request contains following changes to the `Tar` class:

* Adds support for files bigger than 8GiB (see the note on handling out of basic format range values on the https://www.gnu.org/software/tar/manual/html_node/Extensions.html#Extensions). The helper functions were implemented using `static public` methods to make them testable without a need to create >8GiB files.
* Optimizes tar data writing by using a bigger write chunk size (512 bytes at once kills I/O performance on modern storage) and avoiding unnecessary `pack()` calls (only the very last 512 bytes block needs it).
* Adds the `Tar::readCurrentEntry()` method which allows reading tar entry content while iterating trough the archive with the generator returned by the `Tar::yieldContents()`. This allows efficient inspection of large tar archive content without need to extract it. In my particular case it is allows me to check backup consistency with code like
  ```php
  $chunkSize = 1 << 20; // 1MB, whatever
  $tar = new Tar();
  $tar->open('some_archive.tgz');
  foreach($tar->yieldContents() as $i) {
    $hash = hash_init('some algo');
    while ($chunk = $tar->readCurrentEntry($chunkSize)) {
      hash_update($hash, $chunk);
    }
    hash_final($hash);
    if ($hash !== $refHashTakenFromSomewhereElse) {
      throw new Exception('inconsistency!');
    }
  }
  ```
  This code uses constant memory (depending on the `$chunkSize` only) and reads the archive only once no matter the tar archive size and format (compressed or not).