### PR TITLE
validate ZIP central directory and throw on corruption

### DIFF
--- a/src/Zip.php
+++ b/src/Zip.php
@@ -17,6 +17,10 @@ class Zip extends Archive
 {
     const LOCAL_FILE_HEADER_CRC_OFFSET = 14;
 
+    const SIG_LOCAL_FILE_HEADER    = "\x50\x4b\x03\x04";
+    const SIG_CENTRAL_FILE_HEADER  = "\x50\x4b\x01\x02";
+    const SIG_END_OF_CENTRAL_DIR   = "\x50\x4b\x05\x06";
+
     protected $file = '';
     protected $fh;
     protected $memory = '';
@@ -480,7 +484,7 @@ class Zip extends Archive
             $this->writebytes($ctrldir);
 
             // write end of central directory record
-            $this->writebytes("\x50\x4b\x05\x06"); // end of central dir signature
+            $this->writebytes(self::SIG_END_OF_CENTRAL_DIR);
             $this->writebytes(pack('v', 0)); // number of this disk
             $this->writebytes(pack('v', 0)); // number of the disk with the start of the central directory
             $this->writebytes(pack('v',
@@ -553,18 +557,17 @@ class Zip extends Archive
 
         @fseek($this->fh, $size - $maximum_size);
         $pos   = ftell($this->fh);
-        $bytes = 0x00000000;
+        $bytes = '';
 
         while ($pos < $size) {
-            $byte  = @fread($this->fh, 1);
-            $bytes = (($bytes << 8) & 0xFFFFFFFF) | ord($byte);
-            if ($bytes == 0x504b0506) {
+            $bytes = substr($bytes . (string)@fread($this->fh, 1), -4);
+            if ($bytes === self::SIG_END_OF_CENTRAL_DIR) {
                 break;
             }
             $pos++;
         }
 
-        if ($bytes != 0x504b0506) {
+        if ($bytes !== self::SIG_END_OF_CENTRAL_DIR) {
             throw new ArchiveCorruptedException(
                 'End of central directory signature not found - not a valid ZIP file'
             );
@@ -926,7 +929,7 @@ class Zip extends Archive
 
         list($name, $extra) = $this->encodeFilename($name);
 
-        $header = "\x50\x4b\x01\x02"; // central file header signature
+        $header = self::SIG_CENTRAL_FILE_HEADER;
         $header .= pack('v', 14); // version made by - VFAT
         $header .= pack('v', 20); // version needed to extract - 2.0
         $header .= pack('v', 0); // general purpose flag - no flags set
@@ -973,7 +976,7 @@ class Zip extends Archive
 
         list($name, $extra) = $this->encodeFilename($name);
 
-        $header = "\x50\x4b\x03\x04"; //  local file header signature
+        $header = self::SIG_LOCAL_FILE_HEADER;
         $header .= pack('v', 20); // version needed to extract - 2.0
         $header .= pack('v', 0); // general purpose flag - no flags set
         $header .= pack('v', $comp); // compression method - deflate|none

--- a/src/Zip.php
+++ b/src/Zip.php
@@ -89,6 +89,7 @@ class Zip extends Archive
      *
      * @see contents()
      * @throws ArchiveIOException
+     * @throws ArchiveCorruptedException
      * @return FileInfo[]
      */
     public function yieldContents()
@@ -129,6 +130,7 @@ class Zip extends Archive
      * @param string     $exclude a regular expression of files to exclude
      * @param string     $include a regular expression of files to include
      * @throws ArchiveIOException
+     * @throws ArchiveCorruptedException
      * @return FileInfo[]
      */
     public function extract($outdir, $strip = '', $exclude = '', $include = '')
@@ -538,6 +540,7 @@ class Zip extends Archive
      * This key-value list contains general information about the ZIP file
      *
      * @return array
+     * @throws ArchiveCorruptedException when the file is not a valid ZIP archive
      */
     protected function readCentralDir()
     {
@@ -551,20 +554,33 @@ class Zip extends Archive
         @fseek($this->fh, $size - $maximum_size);
         $pos   = ftell($this->fh);
         $bytes = 0x00000000;
+        $found = false;
 
         while ($pos < $size) {
             $byte  = @fread($this->fh, 1);
             $bytes = (($bytes << 8) & 0xFFFFFFFF) | ord($byte);
             if ($bytes == 0x504b0506) {
+                $found = true;
                 break;
             }
             $pos++;
+        }
+
+        if (!$found) {
+            throw new ArchiveCorruptedException(
+                'End of central directory signature not found - not a valid ZIP file'
+            );
         }
 
         $data = unpack(
             'vdisk/vdisk_start/vdisk_entries/ventries/Vsize/Voffset/vcomment_size',
             fread($this->fh, 18)
         );
+        if ($data === false) {
+            throw new ArchiveCorruptedException(
+                'Could not read end of central directory record'
+            );
+        }
 
         if ($data['comment_size'] != 0) {
             $centd['comment'] = fread($this->fh, $data['comment_size']);

--- a/src/Zip.php
+++ b/src/Zip.php
@@ -554,19 +554,17 @@ class Zip extends Archive
         @fseek($this->fh, $size - $maximum_size);
         $pos   = ftell($this->fh);
         $bytes = 0x00000000;
-        $found = false;
 
         while ($pos < $size) {
             $byte  = @fread($this->fh, 1);
             $bytes = (($bytes << 8) & 0xFFFFFFFF) | ord($byte);
             if ($bytes == 0x504b0506) {
-                $found = true;
                 break;
             }
             $pos++;
         }
 
-        if (!$found) {
+        if ($bytes != 0x504b0506) {
             throw new ArchiveCorruptedException(
                 'End of central directory signature not found - not a valid ZIP file'
             );

--- a/tests/ZipTestCase.php
+++ b/tests/ZipTestCase.php
@@ -53,6 +53,41 @@ class ZipTestCase extends TestCase
     }
 
     /**
+     * Feeding a file without an End-of-Central-Directory signature must raise
+     * ArchiveCorruptedException, not bubble up PHP warnings from unpack().
+     */
+    public function testNotAZip()
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'phpa-bad-');
+        file_put_contents($tmp, str_repeat('this is not a zip file ', 50));
+        try {
+            $zip = new Zip();
+            $zip->open($tmp);
+            $this->expectException(ArchiveCorruptedException::class);
+            iterator_to_array($zip->yieldContents());
+        } finally {
+            @unlink($tmp);
+        }
+    }
+
+    /**
+     * A truncated file (smaller than the EOCD record) must also fail cleanly.
+     */
+    public function testTruncatedFile()
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'phpa-trunc-');
+        file_put_contents($tmp, "PK\x03\x04");
+        try {
+            $zip = new Zip();
+            $zip->open($tmp);
+            $this->expectException(ArchiveCorruptedException::class);
+            iterator_to_array($zip->yieldContents());
+        } finally {
+            @unlink($tmp);
+        }
+    }
+
+    /**
      * simple test that checks that the given filenames and contents can be grepped from
      * the uncompressed zip stream
      *

--- a/tests/ZipTestCase.php
+++ b/tests/ZipTestCase.php
@@ -58,14 +58,15 @@ class ZipTestCase extends TestCase
      */
     public function testNotAZip()
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'phpa-bad-');
+        $tmp = sys_get_temp_dir() . '/phpa-bad-' . md5(uniqid('', true)) . '.bin';
         file_put_contents($tmp, str_repeat('this is not a zip file ', 50));
+        $zip = new Zip();
+        $zip->open($tmp);
         try {
-            $zip = new Zip();
-            $zip->open($tmp);
             $this->expectException(ArchiveCorruptedException::class);
             iterator_to_array($zip->yieldContents());
         } finally {
+            try { $zip->close(); } catch (\Exception $e) { /* already errored */ }
             @unlink($tmp);
         }
     }
@@ -75,14 +76,15 @@ class ZipTestCase extends TestCase
      */
     public function testTruncatedFile()
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'phpa-trunc-');
+        $tmp = sys_get_temp_dir() . '/phpa-trunc-' . md5(uniqid('', true)) . '.bin';
         file_put_contents($tmp, "PK\x03\x04");
+        $zip = new Zip();
+        $zip->open($tmp);
         try {
-            $zip = new Zip();
-            $zip->open($tmp);
             $this->expectException(ArchiveCorruptedException::class);
             iterator_to_array($zip->yieldContents());
         } finally {
+            try { $zip->close(); } catch (\Exception $e) { /* already errored */ }
             @unlink($tmp);
         }
     }


### PR DESCRIPTION
The readCentralDir() scan for the End-of-Central-Directory signature
silently fell through when it was missing, leaving the file pointer
past EOF and feeding null to unpack(). That surfaced as PHP warnings
("unpack(): Type V: not enough input") rather than a meaningful error.

Detect both the missing EOCD signature and a failed unpack() and raise
ArchiveCorruptedException instead, matching the error handling used
elsewhere in the package. Added tests covering a non-ZIP payload and
a file too short to hold an EOCD record.